### PR TITLE
Updated notebook processing script to fix dat references.

### DIFF
--- a/notebooks/01/Modules-and-Files.ipynb
+++ b/notebooks/01/Modules-and-Files.ipynb
@@ -288,7 +288,7 @@
     }
    ],
    "source": [
-    "file = open('../data/fifth_republic.txt', 'r') \n",
+    "file = open('https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/fifth_republic.txt', 'r') \n",
     "#open fifth_republic.txt for reading ('r')\n",
     "for line in file:\n",
     "    # Repeat the first 5 characters 3 times\n",
@@ -342,7 +342,7 @@
     }
    ],
    "source": [
-    "file = open('../data/fifth_republic.txt', 'r')\n",
+    "file = open('https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/fifth_republic.txt', 'r')\n",
     "#open fifth_republic.txt for reading ('r')\n",
     "\n",
     "# Read the first line\n",
@@ -453,7 +453,7 @@
     }
    ],
    "source": [
-    "writeFile = open(\"../data/hats.txt\",\"w\") \n",
+    "writeFile = open(\"https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/hats.txt\",\"w\") \n",
     "#open hats.txt to write (clobber if it exists)\n",
     "hats = [\"fedora\",\"trilby\",\"porkpie\",\n",
     "        \"tam o'shanter\",\"Phrygian cap\",\"Beefeaters' hat\",\"sombrero\"]\n",
@@ -462,7 +462,7 @@
     "writeFile.close()\n",
     "\n",
     "#now open file and print\n",
-    "readFile = open(\"../data/hats.txt\",\"r\")\n",
+    "readFile = open(\"https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/hats.txt\",\"r\")\n",
     "for line in readFile:\n",
     "    print(line)\n",
     "readFile.close()"
@@ -504,7 +504,7 @@
    ],
    "source": [
     "import csv\n",
-    "file = open('../data/fifth_republic.txt', 'r')\n",
+    "file = open('https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/fifth_republic.txt', 'r')\n",
     "for i,row in enumerate(file):\n",
     "    print(row)"
    ]

--- a/notebooks/01/Pandas.ipynb
+++ b/notebooks/01/Pandas.ipynb
@@ -81,7 +81,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "low = pd.read_csv('../data/table1-1.csv')"
+    "low = pd.read_csv('https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/table1-1.csv')"
    ]
   },
   {

--- a/notebooks/01/Python-Basics-III-Lists-Dictionaries-Enumeration.ipynb
+++ b/notebooks/01/Python-Basics-III-Lists-Dictionaries-Enumeration.ipynb
@@ -674,7 +674,7 @@
     "element_dict = {} #create a blank dictionary\n",
     "\n",
     "# this block will only execute if the file opens\n",
-    "with open('../data/ChemicalSymbols.csv') as csvfile: \n",
+    "with open('https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/ChemicalSymbols.csv') as csvfile: \n",
     "    chemreader = csv.reader(csvfile)\n",
     "    for row in chemreader: # have for loop that loops over each line\n",
     "        element_dict[row[0]] = row[1] # add a key:value pair\n",

--- a/notebooks/07/Electricity-Market-Optimization.ipynb
+++ b/notebooks/07/Electricity-Market-Optimization.ipynb
@@ -150,7 +150,7 @@
     }
    ],
    "source": [
-    "data = pd.read_csv('../data/Prices_DAM_ALTA2G_7_B1.csv',names=['Price'])\n",
+    "data = pd.read_csv('https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/Prices_DAM_ALTA2G_7_B1.csv',names=['Price'])\n",
     "data.head()"
    ]
   },

--- a/notebooks/08/Summary-Statistics.ipynb
+++ b/notebooks/08/Summary-Statistics.ipynb
@@ -198,8 +198,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "low = pd.read_csv('../data/table1-1.csv')\n",
-    "high = pd.read_csv('../data/table1-2.csv')"
+    "low = pd.read_csv('https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/table1-1.csv')\n",
+    "high = pd.read_csv('https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/table1-2.csv')"
    ]
   },
   {
@@ -1690,7 +1690,7 @@
    "outputs": [],
    "source": [
     "# Open the file\n",
-    "exam1_full = pd.read_csv(\"../data/Exam_1_scores.csv\")"
+    "exam1_full = pd.read_csv(\"https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/Exam_1_scores.csv\")"
    ]
   },
   {

--- a/notebooks/08/Visualizing-Data.ipynb
+++ b/notebooks/08/Visualizing-Data.ipynb
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "exam1_full = pd.read_csv(\"../data/Exam_1_scores.csv\")\n",
+    "exam1_full = pd.read_csv(\"https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/Exam_1_scores.csv\")\n",
     "# create empty dictionary\n",
     "new_data = {}\n",
     "new_data['Total'] = exam1_full['Total Score']\n",
@@ -142,7 +142,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "old_faithful = pd.read_csv('../data/table1-6.csv')"
+    "old_faithful = pd.read_csv('https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/table1-6.csv')"
    ]
   },
   {

--- a/notebooks/09/Random-Variables.ipynb
+++ b/notebooks/09/Random-Variables.ipynb
@@ -586,7 +586,7 @@
     }
    ],
    "source": [
-    "ind_coins_saved = pd.read_csv('../data/two_simple_coins.csv')\n",
+    "ind_coins_saved = pd.read_csv('https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/two_simple_coins.csv')\n",
     "\n",
     "# print first few experiments\n",
     "print(ind_coins_saved.head())\n",

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -51,6 +51,10 @@ def process_notebook(folder_original, folder_new, filename, verbose=1):
     replace_code(SOLUTION_CODE, "# Add your solution here")
     replace_code(HIDDEN_TESTS, "# Removed autograder test. You may delete this cell.")
     
+    OLD_DATA_PATH = "../data/"
+    NEW_DATA_PATH = "https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/"    
+    replace_code(OLD_DATA_PATH, NEW_DATA_PATH)
+    
     ## Replace elements in markdown cells
     def replace_markdown(pattern, replacement):
         ''' Replace content in markdown by applying regular expression


### PR DESCRIPTION
Fixes #59. This just replaces the `../data` with `https://raw.githubusercontent.com/ndcbe/data-and-computing/main/notebooks/data/` in all of the notebooks. In the future, these data files could be copied to be visible to the HTML page. But this should work for now.