### PR TITLE
Fix sign on the Taylor remainder term in the trapezoid derivation

### DIFF
--- a/notebooks/07-dev/Intro-and-Newton-Cotes.ipynb
+++ b/notebooks/07-dev/Intro-and-Newton-Cotes.ipynb
@@ -1366,7 +1366,7 @@
     "\n",
     "Additionally,\n",
     "\n",
-    "$$\\int\\limits_a^b \\frac{(x-a)^2}{2} f''(a)\\,dx = -\\frac{h^3}{6} f''(a) = O(h^3).$$\n",
+    "$$\\int\\limits_a^b \\frac{(x-a)^2}{2} f''(a)\\,dx = \\frac{h^3}{6} f''(a) = O(h^3).$$\n",
     "\n",
     "When we plug this into the original integral we get\n",
     "\n",

--- a/notebooks/07/Intro-and-Newton-Cotes.ipynb
+++ b/notebooks/07/Intro-and-Newton-Cotes.ipynb
@@ -1263,7 +1263,7 @@
     "\n",
     "Additionally,\n",
     "\n",
-    "$$\\int\\limits_a^b \\frac{(x-a)^2}{2} f''(a)\\,dx = -\\frac{h^3}{6} f''(a) = O(h^3).$$\n",
+    "$$\\int\\limits_a^b \\frac{(x-a)^2}{2} f''(a)\\,dx = \\frac{h^3}{6} f''(a) = O(h^3).$$\n",
     "\n",
     "When we plug this into the original integral we get\n",
     "\n",


### PR DESCRIPTION
### The problem

`notebooks/07/Intro-and-Newton-Cotes.ipynb`, in the Taylor-series derivation of the trapezoid rule, prints

$$\int_a^b \frac{(x-a)^2}{2} f''(a)\,dx = -\frac{h^3}{6} f''(a) = O(h^3)$$

**The minus sign is wrong.** Antidifferentiating gives $f''(a)\frac{(x-a)^3}{6}$ evaluated from $a$ to $b$, i.e. $+\frac{h^3}{6}f''(a)$ for $h = b - a > 0$. Verified symbolically with sympy.

### Why it is worth fixing anyway

Nothing downstream changes — the term is absorbed into $O(h^3)$ on the same line, so the conclusion that one panel of the trapezoid rule is third-order accurate (and $O(h^2)$ composite) is unaffected.

But this is a page where students are walked through the algebra line by line, and a reader who checks the integral will find it does not come out. That is exactly the reader the derivation is written for.

### The change

One character, in two files — the `-dev` source and the published copy, kept in sync:

- `notebooks/07-dev/Intro-and-Newton-Cotes.ipynb`
- `notebooks/07/Intro-and-Newton-Cotes.ipynb`

No code cells touched, no outputs changed, no other prose modified.

### Context

Found while cross-checking numeric-integration material for the Fall 2026 refresh of the optimization course, which draws on this chapter. **The same slip appears in at least two other places** and may be worth a look separately:

- `nsa-fall-2019/Lectures/C12-Numeric-Integration/C12-Numeric-Integration.ipynb` (markdown cell 56) — co-authored with Ryan McClarren, so worth a word with him first
- the corresponding handwritten Class 12 notes, which carry a *different, independent* slip in the same term (third derivative where the second is meant)

Separately, and **not** part of this PR: the same chapter's exercise "derive the error order for midpoint and trapezoid rules" is stated without giving an answer, which is correct — the midpoint rule is $O(h^2)$ composite, not $O(h)$, because node symmetry buys a free order that the interpolant-degree heuristic misses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)